### PR TITLE
Comply parameters of addCss() to Bolt\BaseExtension

### DIFF
--- a/src/ExtensionHelper.php
+++ b/src/ExtensionHelper.php
@@ -138,7 +138,7 @@ abstract class ExtensionHelper extends BaseExtension
      *
      * @see \Bolt\BaseExtension::addCSS()
      */
-    public function addCSS($filename, $late = false)
+    public function addCSS($filename, $late = false, $priority = 0)
     {
         return $this->addAsset('CSS', $filename, $late);
     }


### PR DESCRIPTION
Using the current build:


    [05-Jan-2015 18:58:49 UTC] PHP Strict Standards:  Declaration of Bolt\Extension\Bolt\Editable\ExtensionHelper::addCSS() should be compatible with Bolt\BaseExtension::addCSS($filename, $late = false, $priority = 0) in /***/***/extensions/vendor/bolt/editable/src/ExtensionHelper.php on line 8