### PR TITLE
Fix access level to $config

### DIFF
--- a/src/ExtensionHelper.php
+++ b/src/ExtensionHelper.php
@@ -12,7 +12,7 @@ abstract class ExtensionHelper extends BaseExtension
 
     protected $resourcePaths;
 
-    protected $config;
+    public $config;
 
     protected $baseUrl;
 


### PR DESCRIPTION
Access level to Bolt\Extension\Bolt\Editable\ExtensionHelper::$config must be public (as in class Bolt\BaseExtension)
